### PR TITLE
Use specific SNS/SQS gems over full aws-sdk

### DIFF
--- a/lib/sensu/transport/snssqs.rb
+++ b/lib/sensu/transport/snssqs.rb
@@ -1,5 +1,6 @@
 require 'sensu/transport/base'
-require 'aws-sdk'
+require 'aws-sdk-sns'
+require 'aws-sdk-sqs'
 require 'statsd-ruby'
 require 'json'
 require 'retries'

--- a/sensu-transport-snssqs-ng.gemspec
+++ b/sensu-transport-snssqs-ng.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |g|
   g.files = ['lib/sensu/transport/snssqs.rb']
   g.homepage = 'https://github.com/troyready/sensu-transport-snssqs-ng'
   g.licenses = ['Apache-2.0']
-  g.add_dependency('aws-sdk')
+  g.add_dependency('aws-sdk-sns')
+  g.add_dependency('aws-sdk-sqs')
   g.add_dependency('eventmachine')
   g.add_dependency('retries')
   g.add_dependency('statsd-ruby')


### PR DESCRIPTION
aws-sdk is huge and slow to install/load since aws-sdk v3 came out, switching to the specific gems ('aws-sdk-sqs' and 'aws-sdk-sns') speeds this up significantly.